### PR TITLE
Add ansible.cfg to make testing easier

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+callback_plugins = .


### PR DESCRIPTION
It sets `callback_plugins = .` so that you can run something like
`ansible-playbook -i localhost, test/playbooks/echo_ascii.yml`
from a git clone and have it use the plugin.
