### PR TITLE
Don't show blank fields + refactor

### DIFF
--- a/human_log.py
+++ b/human_log.py
@@ -20,20 +20,20 @@ def human_log(callback, host, res):
         #pprint(res)
         for field in FIELDS:
             if field in res.keys():
+                lines = res[field].splitlines()
+                if not lines:
+                    continue
+
                 if 'cmd' in res.keys():
                     print(u'-----> {host} [|] {cmd} [|] {field}'.format(
                         host=host, cmd=res['cmd'], field=field).encode("utf-8"))
-                    lines = res[field].splitlines()
-                    print(u"\n".join([u"       %s" % line for line in lines]).encode("utf-8"))
                 elif 'invocation' in res.keys():
                     print('-----> {host} [|] {module_args} [|] {field}'.format(
                         host=host, module_args=res['invocation']['module_args'], field=field))
-                    lines = res[field].splitlines()
-                    print(u"\n".join([u"       %s" % line for line in lines]).encode("utf-8"))
                 else:
                     print('-----> {host} [|] {field}'.format(host=host, field=field))
-                    lines = res[field].splitlines()
-                    print(u"\n".join([u"       %s" % line for line in lines]).encode("utf-8"))
+
+                print(u"\n".join([u"       %s" % line for line in lines]).encode("utf-8"))
 
 
 class CallbackModule(object):

--- a/test/bats/echo_ascii.bats
+++ b/test/bats/echo_ascii.bats
@@ -5,5 +5,4 @@
   [ "$status" -eq 0 ]
   [[ "$output" = *"-----> localhost [|] echo \"This is plain old ASCII\" [|] stdout"* ]]
   [[ "$output" = *"       This is plain old ASCII"* ]]
-  [[ "$output" = *"-----> localhost [|] echo \"This is plain old ASCII\" [|] stderr"* ]]
 }

--- a/test/bats/echo_unicode.bats
+++ b/test/bats/echo_unicode.bats
@@ -5,5 +5,4 @@
   [ "$status" -eq 0 ]
   [[ "$output" = *"-----> localhost [|] echo \"测试\" [|] stdout"* ]]
   [[ "$output" = *"       测试"* ]]
-  [[ "$output" = *"-----> localhost [|] echo \"测试\" [|] stderr"* ]]
 }


### PR DESCRIPTION
This would show `stderr` before even if it was blank; now it will omit it.

And the code has less duplication.

Cc: @georges, @0x9900

```
$ ( cd smstack/ansible ; ansible-playbook mt.yml -e hosts=tcserver2 -i tcserver2, --skip-tags=consul,splunk,newrelic -e deploy_env=unknown )
...
TASK: [nova | nova flavor-list] ***********************************************
changed: [tcserver2 -> 127.0.0.1]
-----> tcserver2 -> 127.0.0.1 [|] nova flavor-list [|] stdout
       +--------------------------------------+-----------------------+-----------+------+-----------+------+-------+-------------+-----------+
       | ID                                   | Name                  | Memory_MB | Disk | Ephemeral | Swap | VCPUs | RXTX_Factor | Is_Public |
       +--------------------------------------+-----------------------+-----------+------+-----------+------+-------+-------------+-----------+
       | 090ced45-e00a-4c07-939b-b91fbb22ff58 | dev.large             | 8192      | 80   | 0         |      | 8     | 1.0         | False     |
       | 18d51748-6a24-4332-a080-d1c77706d4c5 | dev.xsmall            | 1024      | 5    | 0         |      | 1     | 1.0         | False     |
       | 6b4309a2-7580-4bc7-996a-96854fad3bb8 | mc-test-flavor        | 2048      | 0    | 0         |      | 1     | 1.0         | True      |
       | 6f04f02b-f42c-42b1-a79c-fcc36c9a887b | dev.default_plus      | 8192      | 20   | 0         |      | 2     | 1.0         | False     |
       | 832a3cc3-9c0c-4334-8a3a-5b0534940b4b | dev.medium            | 4096      | 20   | 0         |      | 4     | 1.0         | False     |
       | 8e821c69-d045-4df1-af26-856a201e6fd1 | dev.default           | 2048      | 10   | 0         |      | 2     | 1.0         | False     |
       | a4fed8c7-6b17-49ee-86a8-f0243493ce2a | dev.small             | 2048      | 5    | 0         |      | 2     | 1.0         | False     |
       | b8f518f4-619f-4aa4-88c1-b085b1b6d0d1 | dev.xplus             | 20480     | 20   | 0         |      | 4     | 1.0         | False     |
       | cd9c03fc-0d2d-47e8-ada6-61ffaf631eae | dev.special           | 16384     | 80   | 0         |      | 8     | 1.0         | False     |
       | d2e189ee-36be-4ec1-acba-23e0ffdcccfd | dev.massive           | 40960     | 20   | 0         |      | 8     | 1.0         | False     |
       | f183f6c4-9905-4f34-98d8-014006ac7b4b | dev.default_plus_plus | 8192      | 20   | 0         |      | 4     | 1.0         | False     |
       +--------------------------------------+-----------------------+-----------+------+-----------+------+-------+-------------+-----------+
```
